### PR TITLE
Remove Wine

### DIFF
--- a/assets/firestorm-viewer
+++ b/assets/firestorm-viewer
@@ -3,7 +3,7 @@ APPPATH=/app/extra
 
 ## Start the binary directly and avoid the upstream launcher script. It's pointless here because inside a Flatpak the environment is always the same.
 FIRESTORMBIN=$APPPATH/bin/do-not-directly-run-firestorm-bin
-PARAMS="--set FSLinuxEnableWin32VoiceProxy TRUE --setdefault FSLinuxEnableWin32VoiceProxy TRUE --set CacheLocation $XDG_CACHE_HOME/firestorm --set NewCacheLocation $XDG_CACHE_HOME/firestorm --set ExternalEditor /usr/bin/xdg-open"
+PARAMS="--set FSLinuxEnableWin32VoiceProxy FALSE --setdefault FSLinuxEnableWin32VoiceProxy FALSE --set CacheLocation $XDG_CACHE_HOME/firestorm --set NewCacheLocation $XDG_CACHE_HOME/firestorm --set ExternalEditor /usr/bin/xdg-open"
 
 ## The non-deferred render does not work under Xwayland, this makes sure it will always be disabled.
 if [ ! -z $WAYLAND_DISPLAY ]; then
@@ -23,7 +23,6 @@ function prepareDiscord {
 export SDL_VIDEO_X11_DGAMOUSE=0
 # This makes the tmpdir something the host can resolve, this is only used for editing scripts in an external editor.
 export TMPDIR=$XDG_CACHE_HOME/tmp
-export WINEPREFIX=$XDG_DATA_HOME/wine
 
 cd $APPPATH
 

--- a/org.firestormviewer.FirestormViewer.json
+++ b/org.firestormviewer.FirestormViewer.json
@@ -1,157 +1,172 @@
 {
-  "app-id":"org.firestormviewer.FirestormViewer",
-  "runtime":"org.freedesktop.Platform",
-  "runtime-version":"20.08",
-  "sdk":"org.freedesktop.Sdk",
-  "command":"firestorm-viewer",
-  "separate-locales":false,
-  "finish-args":[
-    "--share=ipc",
-    "--socket=x11",
-    "--socket=pulseaudio",
-    "--share=network",
-    "--allow=multiarch",
-    "--device=dri",
-    "--filesystem=~/.firestorm_x64:create",
-    "--filesystem=xdg-desktop",
-    "--filesystem=xdg-documents",
-    "--filesystem=xdg-download",
-    "--filesystem=xdg-music",
-    "--filesystem=xdg-pictures",
-    "--filesystem=xdg-run/app/com.discordapp.Discord:create",
-    "--talk-name=org.freedesktop.Notifications",
-    "--own-name=com.secondlife.ViewerAppAPIService",
-    "--env=LD_LIBRARY_PATH=/app/extra/lib/"
-  ],
-  "cleanup":[
-    "/share/man",
-    "/share/doc",
-    "/share/gtk-doc",
-    "/lib/pkgconfig",
-    "/lib/debug"
-  ],
-  "build-options":{
-    "strip":true
-  },
-  "add-extensions":{
-    "org.freedesktop.Platform.Compat.i386":{
-      "directory":"lib/i386-linux-gnu",
-      "version":"20.08"
-    }
-  },
-  "sdk-extensions":[
-    "org.freedesktop.Sdk.Compat.i386",
-    "org.freedesktop.Sdk.Extension.toolchain-i386"
-  ],
-  "modules":[
-    "shared-modules/glu/glu-9.json",
-    "shared-modules/gtk2/gtk2.json",
-    "shared-modules/dbus-glib/dbus-glib-0.110.json",
-    {
-      "name":"wine",
-      "build-options":{
-        "make-args":[
-          "--silent"
-        ],
-        "arch":{
-          "x86_64":{
-            "prepend-pkg-config-path":"/app/lib32/pkgconfig:/usr/lib/i386-linux-gnu/pkgconfig",
-            "ldflags":"-L/app/lib32",
-            "append-path":"/usr/lib/sdk/toolchain-i386/bin",
-            "env":{
-              "CC":"i686-unknown-linux-gnu-gcc",
-              "CXX":"i686-unknown-linux-gnu-g++"
-            },
-            "libdir":"/app/lib32"
-          }
-        }
-      },
-      "config-opts": [
-        "--without-vkd3d",
-        "--without-xinput",
-        "--without-xinput2"
-      ],
-      "sources":[
-        {
-          "type":"archive",
-          "url":"https://dl.winehq.org/wine/source/5.x/wine-5.21.tar.xz",
-          "sha256":"5a1a5c2549d11bce0d6640220ed6fd31042afcbcb366f475e0ccb4781d2d2840"
-        }
-      ]
+    "app-id":"org.firestormviewer.FirestormViewer",
+    "runtime":"org.freedesktop.Platform",
+    "runtime-version":"20.08",
+    "sdk":"org.freedesktop.Sdk",
+    "command":"firestorm-viewer",
+    "separate-locales":false,
+    "finish-args":[
+        "--share=ipc",
+        "--socket=x11",
+        "--socket=pulseaudio",
+        "--share=network",
+        "--allow=multiarch",
+        "--device=dri",
+        "--filesystem=~/.firestorm_x64:create",
+        "--filesystem=xdg-desktop",
+        "--filesystem=xdg-documents",
+        "--filesystem=xdg-download",
+        "--filesystem=xdg-music",
+        "--filesystem=xdg-pictures",
+        "--filesystem=xdg-run/app/com.discordapp.Discord:create",
+        "--talk-name=org.freedesktop.Notifications",
+        "--talk-name=org.freedesktop.secrets",
+        "--own-name=com.secondlife.ViewerAppAPIService",
+        "--env=LD_LIBRARY_PATH=/app/extra/lib/:/app/lib32/"
+    ],
+    "cleanup":[
+        "/share/man",
+        "/share/doc",
+        "/share/gtk-doc",
+        "/lib/pkgconfig",
+        "/lib/debug"
+    ],
+    "build-options":{
+        "strip":true
     },
-    {
-      "name":"libnotify",
-      "buildsystem":"meson",
-      "config-opts":[
-        "-Ddocbook_docs=disabled",
-        "-Dintrospection=disabled",
-        "-Dtests=false",
-        "-Dgtk_doc=false",
-        "-Dman=false"
-      ],
-      "cleanup":[
-        "/bin"
-      ],
-      "sources":[
-        {
-          "type":"archive",
-          "url":"https://download.gnome.org/sources/libnotify/0.7/libnotify-0.7.9.tar.xz",
-          "sha256":"66c0517ed16df7af258e83208faaf5069727dfd66995c4bbc51c16954d674761"
+    "add-extensions":{
+        "org.freedesktop.Platform.Compat.i386":{
+            "directory":"lib/i386-linux-gnu",
+            "version":"20.08"
         }
-      ]
     },
-    {
-      "name":"firestorm",
-      "buildsystem":"simple",
-      "sources":[
+    "sdk-extensions":[
+        "org.freedesktop.Sdk.Compat.i386",
+        "org.freedesktop.Sdk.Extension.toolchain-i386"
+    ],
+    "modules":[
+        "shared-modules/glu/glu-9.json",
+        "shared-modules/gtk2/gtk2.json",
+        "shared-modules/dbus-glib/dbus-glib-0.110.json",
         {
-          "type":"extra-data",
-          "filename":"viewer.tar.xz",
-          "url":"https://downloads.firestormviewer.org/linux/Phoenix_Firestorm-Release_x86_64_6.4.12.62831.tar.xz",
-          "sha256":"27efc23d33240fad7e9fdaa1adef2d9d9f0dac636e9ddfe13f55a2c735f9ce3e",
-          "size": 175719800
+            "name":"libnotify",
+            "buildsystem":"meson",
+            "config-opts":[
+                "-Ddocbook_docs=disabled",
+                "-Dintrospection=disabled",
+                "-Dtests=false",
+                "-Dgtk_doc=false",
+                "-Dman=false"
+            ],
+            "cleanup":[
+                "/bin"
+            ],
+            "sources":[
+                {
+                    "type":"archive",
+                    "url":"https://download.gnome.org/sources/libnotify/0.7/libnotify-0.7.9.tar.xz",
+                    "sha256":"66c0517ed16df7af258e83208faaf5069727dfd66995c4bbc51c16954d674761"
+                }
+            ]
         },
         {
-          "type": "script",
-          "dest-filename": "apply_extra",
-          "commands": [
-            "tar -xf viewer.tar.xz --strip 1 --no-same-owner",
-            "rm viewer.tar.xz",
-            "cp /app/etc/launch_url.sh etc/"
-          ]
+            "name":"libidn",
+            "sources":[
+                {
+                    "type":"archive",
+                    "url":"https://ftp.gnu.org/gnu/libidn/libidn-1.34.tar.gz",
+                    "sha256":"3719e2975f2fb28605df3479c380af2cf4ab4e919e1506527e4c7670afff6e3c"
+                }
+            ],
+            "build-options":{
+                "arch":{
+                    "x86_64":{
+                        "prepend-pkg-config-path":"/app/lib32/pkgconfig:/usr/lib/i386-linux-gnu/pkgconfig",
+                        "ldflags":"-L/app/lib32",
+                        "append-path":"/usr/lib/sdk/toolchain-i386/bin",
+                        "env":{
+                            "CC":"i686-unknown-linux-gnu-gcc",
+                            "CXX":"i686-unknown-linux-gnu-g++"
+                        },
+                        "libdir":"/app/lib32"
+                    }
+                }
+            }
         },
         {
-          "type":"file",
-          "path":"assets/firestorm-viewer"
+            "name":"libgnome-keyring",
+            "config-opts":[
+                "--disable-static",
+                "--disable-gtk-doc",
+                "--disable-coverage",
+                "--disable-introspection"
+            ],
+            "sources":[
+                {
+                    "type":"archive",
+                    "url":"https://download.gnome.org/sources/libgnome-keyring/3.12/libgnome-keyring-3.12.0.tar.xz",
+                    "sha256":"c4c178fbb05f72acc484d22ddb0568f7532c409b0a13e06513ff54b91e947783"
+                },
+                {
+                    "type":"shell",
+                    "commands":[
+                        "autoreconf -fi"
+                    ]
+                }
+            ]
         },
         {
-          "type":"file",
-          "path":"assets/launch_url.sh"
-        },
-        { 
-          "type":"file",
-          "path":"assets/org.firestormviewer.FirestormViewer.desktop"
-        },
-        {
-          "type":"file",
-          "path":"assets/org.firestormviewer.FirestormViewer.metainfo.xml"
-        },
-        {
-          "type":"file",
-          "url":"https://vcs.firestormviewer.org/phoenix-firestorm-lgpl/raw/5e2050564bd3730f0ce7843860afdb25da3d2346/indra/newview/res/firestorm_icon.png",
-          "sha256": "f51c4c1609d6fe1a75914f3644888816525524e641c2f2821436993921800390",
-          "dest-filename": "org.firestormviewer.FirestormViewer.png"
+            "name":"firestorm",
+            "buildsystem":"simple",
+            "sources":[
+                {
+                    "type":"extra-data",
+                    "filename":"viewer.tar.xz",
+                    "url":"https://downloads.firestormviewer.org/linux/Phoenix_Firestorm-Release_x86_64_6.4.12.62831.tar.xz",
+                    "sha256":"27efc23d33240fad7e9fdaa1adef2d9d9f0dac636e9ddfe13f55a2c735f9ce3e",
+                    "size":175719800
+                },
+                {
+                    "type":"script",
+                    "dest-filename":"apply_extra",
+                    "commands":[
+                        "tar -xf viewer.tar.xz --strip 1 --no-same-owner",
+                        "rm viewer.tar.xz",
+                        "cp /app/etc/launch_url.sh etc/"
+                    ]
+                },
+                {
+                    "type":"file",
+                    "path":"assets/firestorm-viewer"
+                },
+                {
+                    "type":"file",
+                    "path":"assets/launch_url.sh"
+                },
+                {
+                    "type":"file",
+                    "path":"assets/org.firestormviewer.FirestormViewer.desktop"
+                },
+                {
+                    "type":"file",
+                    "path":"assets/org.firestormviewer.FirestormViewer.metainfo.xml"
+                },
+                {
+                    "type":"file",
+                    "url":"https://vcs.firestormviewer.org/phoenix-firestorm-lgpl/raw/5e2050564bd3730f0ce7843860afdb25da3d2346/indra/newview/res/firestorm_icon.png",
+                    "sha256":"f51c4c1609d6fe1a75914f3644888816525524e641c2f2821436993921800390",
+                    "dest-filename":"org.firestormviewer.FirestormViewer.png"
+                }
+            ],
+            "build-commands":[
+                "install apply_extra /app/bin/",
+                "install launch_url.sh /app/etc/",
+                "install -Dm755 firestorm-viewer $FLATPAK_DEST/bin/",
+                "install -Dm644 $FLATPAK_ID.desktop $FLATPAK_DEST/share/applications/$FLATPAK_ID.desktop",
+                "install -Dm644 $FLATPAK_ID.png $FLATPAK_DEST/share/icons/hicolor/512x512/apps/$FLATPAK_ID.png",
+                "install -Dm644 $FLATPAK_ID.metainfo.xml $FLATPAK_DEST/share/metainfo/$FLATPAK_ID.metainfo.xml",
+                "mkdir $FLATPAK_DEST/lib/i386-linux-gnu"
+            ]
         }
-      ],
-      "build-commands":[
-        "install apply_extra /app/bin/",
-        "install launch_url.sh /app/etc/",
-        "install -Dm755 firestorm-viewer $FLATPAK_DEST/bin/",
-        "install -Dm644 $FLATPAK_ID.desktop $FLATPAK_DEST/share/applications/$FLATPAK_ID.desktop",
-        "install -Dm644 $FLATPAK_ID.png $FLATPAK_DEST/share/icons/hicolor/512x512/apps/$FLATPAK_ID.png",
-        "install -Dm644 $FLATPAK_ID.metainfo.xml $FLATPAK_DEST/share/metainfo/$FLATPAK_ID.metainfo.xml",
-        "mkdir $FLATPAK_DEST/lib/i386-linux-gnu"
-      ]
-    }
-  ]
+    ]
 }


### PR DESCRIPTION
The latest Firestorm builds include a native SLVoice linux binary, removing the need for Wine.

However, it's only 32bit, fortunately, the base 32bit compact runtime includes nearly everything it needs except libidn. We'll also force the viewer to disable Wine to prevent issues with upgrading.