### PR TITLE
Update: 6.6.3.x update 

### DIFF
--- a/org.firestormviewer.FirestormViewer.json
+++ b/org.firestormviewer.FirestormViewer.json
@@ -122,7 +122,7 @@
                 {
                     "type":"extra-data",
                     "filename":"viewer.tar.xz",
-                    "url":"https://downloads.firestormviewer.org/preview/linux/Phoenix-FirestormOS-Releasex64-6-6-3-67470.tar.xz",
+                    "url":"https://downloads.firestormviewer.org/linux/Phoenix-FirestormOS-Releasex64-6-6-3-67470.tar.xz",
                     "sha256":"bc4859603b2294bdf5b49ffd2c7db4d1a7aa4c518cf804ecfb19639099c183af",
                     "size": 158039756
                 },

--- a/org.firestormviewer.FirestormViewer.json
+++ b/org.firestormviewer.FirestormViewer.json
@@ -122,9 +122,9 @@
                 {
                     "type":"extra-data",
                     "filename":"viewer.tar.xz",
-                    "url":"https://downloads.firestormviewer.org/linux/Phoenix_FirestormOS-Releasex64_x86_64_6.5.6.66221.tar.xz",
-                    "sha256":"a4e710d7b85fc5e9baaa4d5871c77434b78a0c67fddd9166a09f4429b723b984",
-                    "size": 158597972
+                    "url":"https://downloads.firestormviewer.org/preview/linux/Phoenix-FirestormOS-Releasex64-6-6-3-67470.tar.xz",
+                    "sha256":"bc4859603b2294bdf5b49ffd2c7db4d1a7aa4c518cf804ecfb19639099c183af",
+                    "size": 158039756
                 },
                 {
                     "type":"script",


### PR DESCRIPTION
The Latest beta went into Release Candidate this weekend. This needs some testing, and should not be merged until it's officially released. I will update when the release is ready.

This has inherited at least one bug from the LL viewer which the Firestorm Devs are aware of:
+ Offset Textures updated from scripts sometimes don't update until you force a scene redraw.

Existing bugs that still haven't been fixed:

1. Transparency flickering using AMDGPU if you don't have at least Sun & Moon projectors on
2. Brief client lockup when entering mouselook if you have the UI disabled in mouselook.

These bugs should not prevent a merge as they have been present for at least 12 months and it appears. We're just waiting on them to push this to the official release. All in all this release is a major performance boost, i'm getting 2-3x the performance I had in the last release.