### PR TITLE
Firestorm: update to 6.6.14.69596

### DIFF
--- a/assets/org.firestormviewer.FirestormViewer.metainfo.xml
+++ b/assets/org.firestormviewer.FirestormViewer.metainfo.xml
@@ -14,6 +14,8 @@
   <url type="homepage">https://www.firestormviewer.org/</url>
   <url type="bugtracker">https://github.com/flathub/org.firestormviewer.FirestormViewer</url>
   <releases>
+
+    <release version="6.6.14.69596" date="2023-08-15" />
     <release version="6.6.8.68380" date="2023-01-17" />
     <release version="6.3.9.58205" date="2020-05-28" />
     <release version="6.3.2.58052" date="2019-10-01" />

--- a/org.firestormviewer.FirestormViewer.json
+++ b/org.firestormviewer.FirestormViewer.json
@@ -121,9 +121,9 @@
                 {
                     "type":"extra-data",
                     "filename":"viewer.tar.xz",
-                    "url":"https://downloads.firestormviewer.org/linux/Phoenix-FirestormOS-Releasex64-6-6-8-68380.tar.xz",
-                    "sha256":"ff389b755322df7f5c970e5b4b25258d58210f3d7d0dfdf303cbd29122ba47b8",
-                    "size": 157809668
+                    "url":"https://downloads.firestormviewer.org/linux/Phoenix-FirestormOS-Releasex64-6-6-14-69596.tar.xz",
+                    "sha256":"6e8f901b975a16ec386f74526d8e23431643cadd8bbe1f08f4b2f6544dced42d",
+                    "size": 162431968
                 },
                 {
                     "type":"script",


### PR DESCRIPTION
Updating to the Latest Firestorm. I remember to update the Metainfo this time too so no more people thinking the repo is 3 years out of date, lol.