### PR TITLE
[WIP] Build viewer from source

### DIFF
--- a/org.firestormviewer.FirestormViewer.json
+++ b/org.firestormviewer.FirestormViewer.json
@@ -1,7 +1,7 @@
 {
     "app-id":"org.firestormviewer.FirestormViewer",
     "runtime":"org.freedesktop.Platform",
-    "runtime-version":"22.08",
+    "runtime-version":"23.08",
     "sdk":"org.freedesktop.Sdk",
     "command":"firestorm-viewer",
     "separate-locales":false,
@@ -27,16 +27,16 @@
     "cleanup":[
         "/share/man",
         "/share/doc",
-        "/share/gtk-doc",
-        "/lib/pkgconfig"
+        "/share/gtk-doc"
     ],
+    "writable-sdk": true,
     "build-options":{
         "strip":true
     },
     "add-extensions":{
         "org.freedesktop.Platform.Compat.i386":{
             "directory":"lib/i386-linux-gnu",
-            "version":"22.08"
+            "version":"23.08"
         }
     },
     "sdk-extensions":[
@@ -114,6 +114,18 @@
                 }
             ]
         },
+        "pypi-dependencies.json",
+        {
+          "name": "glu",
+          "buildsystem": "meson",
+          "sources": [
+            {
+              "type": "archive",
+              "url": "https://archive.mesa3d.org/glu/glu-9.0.3.tar.xz",
+              "sha256": "bd43fe12f374b1192eb15fe20e45ff456b9bc26ab57f0eee919f96ca0f8a330f"
+            }
+          ]
+        },
         {
             "name":"ubuntu-libcypto",
             "buildsystem":"simple",
@@ -132,55 +144,31 @@
         },
         {
             "name":"firestorm",
+            "build-options": {
+		        "build-args": [ "--share=network" ]
+	        },
             "buildsystem":"simple",
             "sources":[
                 {
-                    "type":"extra-data",
-                    "filename":"viewer.tar.xz",
-                    "url":"https://downloads.firestormviewer.org/release/linux/Phoenix-FirestormOS-Releasex64-6-6-17-70368.tar.xz",
-                    "sha256":"1adeb5dc1a341ecd1fe858f4fa9e09027c1996f0f8d00c29f3f2d62aeff04dee",
-                    "size": 164189092
+                    "type":"git",
+                    "url":"https://github.com/FirestormViewer/fs-build-variables.git",
+                    "branch": "master",
+                    "dest": "fs-build-variables"
                 },
                 {
-                    "type":"script",
-                    "dest-filename":"apply_extra",
-                    "commands":[
-                        "tar -xf viewer.tar.xz --strip 1 --no-same-owner",
-                        "rm viewer.tar.xz",
-                        "cp /app/etc/launch_url.sh etc/"
-                    ]
-                },
-                {
-                    "type":"file",
-                    "path":"assets/firestorm-viewer"
-                },
-                {
-                    "type":"file",
-                    "path":"assets/launch_url.sh"
-                },
-                {
-                    "type":"file",
-                    "path":"assets/org.firestormviewer.FirestormViewer.desktop"
-                },
-                {
-                    "type":"file",
-                    "path":"assets/org.firestormviewer.FirestormViewer.metainfo.xml"
-                },
-                {
-                    "type":"file",
-                    "url":"https://vcs.firestormviewer.org/phoenix-firestorm-lgpl/raw/5e2050564bd3730f0ce7843860afdb25da3d2346/indra/newview/res/firestorm_icon.png",
-                    "sha256":"f51c4c1609d6fe1a75914f3644888816525524e641c2f2821436993921800390",
-                    "dest-filename":"org.firestormviewer.FirestormViewer.png"
+                    "type":"git",
+                    "url":"https://github.com/FirestormViewer/phoenix-firestorm.git",
+                    "branch":"master",
+                    "dest": "phoenix-firestorm"
                 }
             ],
             "build-commands":[
-                "install apply_extra /app/bin/",
-                "install launch_url.sh /app/etc/",
-                "install -Dm755 firestorm-viewer $FLATPAK_DEST/bin/",
-                "install -Dm644 $FLATPAK_ID.desktop $FLATPAK_DEST/share/applications/$FLATPAK_ID.desktop",
-                "install -Dm644 $FLATPAK_ID.png $FLATPAK_DEST/share/icons/hicolor/512x512/apps/$FLATPAK_ID.png",
-                "install -Dm644 $FLATPAK_ID.metainfo.xml $FLATPAK_DEST/share/metainfo/$FLATPAK_ID.metainfo.xml",
-                "mkdir $FLATPAK_DEST/lib/i386-linux-gnu"
+		"rm /etc/resolv.conf",
+		"echo 'nameserver 8.8.8.8' > /etc/resolv.conf",
+                "cp -v /app/include/GL/glu.h /usr/include/GL/glu.h",
+                "cp -v /app/lib/pkgconfig/glu.pc /usr/lib/x86_64-linux-gnu/pkgconfig/glu.pc",
+        	"cp -v /app/lib/libGLU* /usr/lib/x86_64-linux-gnu/",
+                "cd phoenix-firestorm && AUTOBUILD_VARIABLES_FILE=/run/build/firestorm/fs-build-variables/variables autobuild configure -A 64 -c ReleaseFS_open && AUTOBUILD_VARIABLES_FILE=/run/build/firestorm/fs-build-variables/variables autobuild build -A 64 -c ReleaseFS_open"
             ]
         }
     ]

--- a/pypi-dependencies.json
+++ b/pypi-dependencies.json
@@ -1,0 +1,99 @@
+{
+    "name": "pypi-dependencies",
+    "buildsystem": "simple",
+    "build-commands": [],
+    "modules": [
+        {
+            "name": "python3-llbase",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"llbase\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/ba/06/a07f096c664aeb9f01624f858c3add0a4e913d6c96257acb4fce61e7de14/certifi-2024.2.2-py3-none-any.whl",
+                    "sha256": "dc383c07b76109f368f6106eee2b593b04a011ea4d55f652c6ca24a754d1cdd1"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/63/09/c1bc53dab74b1816a00d8d030de5bf98f724c52c1635e07681d312f20be8/charset-normalizer-3.3.2.tar.gz",
+                    "sha256": "f30c3cb33b24454a82faecaf01b19c18562b1e89558fb6c56de4d9118a032fd5"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/e5/3e/741d8c82801c347547f8a2a06aa57dbb1992be9e948df2ea0eda2c8b79e8/idna-3.7-py3-none-any.whl",
+                    "sha256": "82fee1fc78add43492d3a1898bfa6d8a904cc97d8427f683ed8e798d07761aa0"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/8b/8d/925b7ab9403060c886744858452dc4b048bfde1365c5ed0cd165f3d980f7/llbase-1.3.1-py3-none-any.whl",
+                    "sha256": "bb2f4a808439e788c99de0e1760608a840d7698ed740290151815306a6faef41"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/85/61/9cee6739a249bfd81457213594a0cc19cbf7bb9df24d324af01004df4816/llsd-1.2.4-py3-none-any.whl",
+                    "sha256": "69ebe8ee52c18315ff9a7249ff9b0890a03dcf8bba1718a9ce47e2057faf38aa"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/70/8e/0e2d847013cb52cd35b38c009bb167a1a26b2ce6cd6965bf26b47bc0bf44/requests-2.31.0-py3-none-any.whl",
+                    "sha256": "58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/a2/73/a68704750a7679d0b6d3ad7aa8d4da8e14e151ae82e6fee774e6e0d05ec8/urllib3-2.2.1-py3-none-any.whl",
+                    "sha256": "450b20ec296a467077128bff42b73080516e71b56ff59a60a02bef2232c4fa9d"
+                }
+            ]
+        },
+        {
+            "name": "python3-autobuild",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"autobuild\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/e5/e0/bf7429225e2a06fd12eb7307426a7fb7e171697aa0fc5f8c274254e29567/autobuild-3.9.5-py3-none-any.whl",
+                    "sha256": "425fbc56781a918a94cf19928073d22e84dfca2a6813435da88ecb75f6c2b742"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/85/61/9cee6739a249bfd81457213594a0cc19cbf7bb9df24d324af01004df4816/llsd-1.2.4-py3-none-any.whl",
+                    "sha256": "69ebe8ee52c18315ff9a7249ff9b0890a03dcf8bba1718a9ce47e2057faf38aa"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/7f/90/c9b51f3cdff89cd8f93382060330f43d1af098a6624cff439e700791e922/pydot-2.0.0-py3-none-any.whl",
+                    "sha256": "408a47913ea7bd5d2d34b274144880c1310c4aee901f353cf21fe2e526a4ea28"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/9d/ea/6d76df31432a0e6fdf81681a895f009a4bb47b3c39036db3e1b528191d52/pyparsing-3.1.2-py3-none-any.whl",
+                    "sha256": "f9db75911801ed778fe61bb643079ff86601aca99fcae6345aa67292038fb742"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/0f/ae/dc18432a364b34e7adbc0edc32de44dd5310184112945552c106ab913f39/pyzstd-0.15.10.tar.gz",
+                    "sha256": "83603a97fdbcf2139f475c940789f09e32703f931f29f4a8ddf3551e6700108b"
+                }
+            ]
+        },
+        {
+            "name": "python3-llsd",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"llsd\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/85/61/9cee6739a249bfd81457213594a0cc19cbf7bb9df24d324af01004df4816/llsd-1.2.4-py3-none-any.whl",
+                    "sha256": "69ebe8ee52c18315ff9a7249ff9b0890a03dcf8bba1718a9ce47e2057faf38aa"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
This attempts to build the viewer from source, which paves the way for arm64 support and reproducible builds. It also avoids failed downloads due to Cloudflare screening on the tarball URL.

There are some problems with this, so it's still marked as a WIP
- desktop files are currently not exported
- uses `writable-sdk` so the GLU headers can be copied to /usr, this is because the upstream CMake files are extremely messy and hellbent on GL and GLU being in the same place and I couldn't figure out how to fix them
- needs network access for autobuild to succeed in pulling additional dependencies such as ogg-vorbis


I found that using `writable-sdk` broke /etc/resolv.conf in the build sandbox so we have to overwrite too.