### PR TITLE
Update source to 7.1.13.77930 (beta channel)

### DIFF
--- a/assets/org.firestormviewer.FirestormViewer.metainfo.xml
+++ b/assets/org.firestormviewer.FirestormViewer.metainfo.xml
@@ -16,6 +16,7 @@
   <url type="homepage">https://www.firestormviewer.org/</url>
   <url type="bugtracker">https://github.com/flathub/org.firestormviewer.FirestormViewer</url>
   <releases>
+    <release version="7.1.13.77930" date="2025-04-25" />
     <release version="7.1.12.77211" date="2025-01-07" />
     <release version="7.1.11.76496" date="2024-10-22" />
     <release version="7.1.10.79513" date="2024-09-17" />

--- a/org.firestormviewer.FirestormViewer.json
+++ b/org.firestormviewer.FirestormViewer.json
@@ -103,9 +103,9 @@
                 {
                     "type":"extra-data",
                     "filename":"viewer.tar.xz",
-                    "url":"https://downloads.firestormviewer.org/preview/linux/Phoenix-Firestorm-Betax64_AVX2-7-1-12-77526.tar.xz",
-                    "sha256":"533b6be1af9f9faaef552049a2264c322b5671917b7010e8580c8f0ef4015b7e",
-                    "size": 185974228
+                    "url":"https://downloads.firestormviewer.org/preview/linux/Phoenix-Firestorm-Betax64_AVX2-7-1-13-77930.tar.xz",
+                    "sha256":"80b71ff50dd3b6d817b993ee2db93de777971c2126fec84df93994217245146f",
+                    "size": 186265184
                 },
                 {
                     "type":"script",


### PR DESCRIPTION
Updated to 7.1.13.77930 as 7.1.12.77211 has expired.

Updated URL, SHA256, and size for the new beta release.