### PR TITLE
Enable "input" permission to allow game controller support.

### DIFF
--- a/org.firestormviewer.FirestormViewer.json
+++ b/org.firestormviewer.FirestormViewer.json
@@ -12,6 +12,7 @@
         "--share=network",
         "--allow=multiarch",
         "--device=dri",
+        "--device=input",
         "--filesystem=~/.firestorm_x64:create",
         "--filesystem=xdg-desktop",
         "--filesystem=xdg-documents",


### PR DESCRIPTION
Enable input permissions to add support for game controllers, e.g. Xbox 360 controllers, Steam Deck controller.