### PR TITLE
Fix GPU detection on hybrid systems

### DIFF
--- a/assets/org.firestormviewer.FirestormViewer.desktop
+++ b/assets/org.firestormviewer.FirestormViewer.desktop
@@ -9,4 +9,9 @@ Type=Application
 Terminal=false
 StartupWMClass=do-not-directly-run-firestorm-bin
 MimeType=x-scheme-handler/secondlife;
+PrefersNonDefaultGPU=true
+Actions=DefaultGPU;
 
+[Desktop Action DefaultGPU]
+Exec=env __GLX_VENDOR_LIBRARY_NAME="" firestorm-viewer %U
+Name=Launch on default GPU


### PR DESCRIPTION
Fix GPU detection on systems equipped with hybrid graphics (e.g. laptops with a dGPU). Also adds in a secondary option to launch on the iGPU if desired.

This change does not affect single-GPU systems.