### PR TITLE
Update Runtime to 25.08 / Fix CEF

### DIFF
--- a/assets/firestorm-viewer
+++ b/assets/firestorm-viewer
@@ -17,8 +17,8 @@ function prepareDiscord {
 ## Avoids an often-buggy X feature that doesn't really benefit us anyway.
 export SDL_VIDEO_X11_DGAMOUSE=0
 # This makes the tmpdir something the host can resolve, this is only used for editing scripts in an external editor.
-# Somehow breaks CEF?
-# export TMPDIR=$XDG_CACHE_HOME/tmp
+mkdir -p $HOME/.firestorm_x64/cache
+export TMPDIR=$HOME/.firestorm_x64/cache/
 
 ## Enable nVidia threaded optimizations, this seems to be a free performance gain - see https://github.com/FirestormViewer/phoenix-firestorm/commit/ccaab5c0b8a4c506df566a195bc19567404b3589
 export __GL_THREADED_OPTIMIZATIONS=1

--- a/assets/firestorm-viewer
+++ b/assets/firestorm-viewer
@@ -3,12 +3,7 @@ APPPATH=/app/extra
 
 ## Start the binary directly and avoid the upstream launcher script. It's pointless here because inside a Flatpak the environment is always the same.
 FIRESTORMBIN=$APPPATH/bin/do-not-directly-run-firestorm-bin
-PARAMS="--set FSLinuxEnableWin32VoiceProxy FALSE --setdefault FSLinuxEnableWin32VoiceProxy FALSE --set CacheLocation $XDG_CACHE_HOME/firestorm --set NewCacheLocation $XDG_CACHE_HOME/firestorm --set ExternalEditor /usr/bin/xdg-open"
-
-## The non-deferred render does not work under Xwayland, this makes sure it will always be disabled.
-if [ ! -z $WAYLAND_DISPLAY ]; then
-  PARAMS+=" --set RenderDeferred TRUE"
-fi
+PARAMS="--set CacheLocation $XDG_CACHE_HOME/firestorm --set NewCacheLocation $XDG_CACHE_HOME/firestorm --set ExternalEditor /usr/bin/xdg-open"
 
 function prepareDiscord {
   ## Discord RPC support
@@ -22,7 +17,8 @@ function prepareDiscord {
 ## Avoids an often-buggy X feature that doesn't really benefit us anyway.
 export SDL_VIDEO_X11_DGAMOUSE=0
 # This makes the tmpdir something the host can resolve, this is only used for editing scripts in an external editor.
-export TMPDIR=$XDG_CACHE_HOME/tmp
+# Somehow breaks CEF?
+# export TMPDIR=$XDG_CACHE_HOME/tmp
 
 ## Enable nVidia threaded optimizations, this seems to be a free performance gain - see https://github.com/FirestormViewer/phoenix-firestorm/commit/ccaab5c0b8a4c506df566a195bc19567404b3589
 export __GL_THREADED_OPTIMIZATIONS=1

--- a/org.firestormviewer.FirestormViewer.json
+++ b/org.firestormviewer.FirestormViewer.json
@@ -11,13 +11,16 @@
         "--socket=pulseaudio",
         "--share=network",
         "--allow=multiarch",
-        "--device=dri",
+        /* Nvidia seems to get messed with just device-dri on CEF?*/
+        "--device=all",
         "--filesystem=~/.firestorm_x64:create",
         "--filesystem=xdg-desktop",
         "--filesystem=xdg-documents",
         "--filesystem=xdg-download",
         "--filesystem=xdg-music",
         "--filesystem=xdg-pictures",
+        /* Needed for CEF*/
+        "--filesystem=/run/user",
         "--filesystem=xdg-run/app/com.discordapp.Discord:create",
         "--talk-name=org.freedesktop.Notifications",
         "--talk-name=org.freedesktop.secrets",
@@ -33,16 +36,6 @@
     "build-options":{
         "strip":true
     },
-    "add-extensions":{
-        "org.freedesktop.Platform.Compat.i386":{
-            "directory":"lib/i386-linux-gnu",
-            "version":"23.08"
-        }
-    },
-    "sdk-extensions":[
-        "org.freedesktop.Sdk.Compat.i386",
-        "org.freedesktop.Sdk.Extension.toolchain-i386"
-    ],
     "modules":[
         "shared-modules/glu/glu-9.json",
         "shared-modules/gtk2/gtk2.json",
@@ -63,71 +56,9 @@
             "sources":[
                 {
                     "type":"archive",
-                    "url":"https://download.gnome.org/sources/libnotify/0.8/libnotify-0.8.3.tar.xz",
-                    "sha256":"ee8f3ef946156ad3406fdf45feedbdcd932dbd211ab4f16f75eba4f36fb2f6c0"
+                    "url":"https://download.gnome.org/sources/libnotify/0.8/libnotify-0.8.6.tar.xz",
+                    "sha256":"c5540aaefb60e1d63b1c587c05f2284ebe72ece7d0c0e5e4a778cfd5844b6b58"
                 }
-            ]
-        },
-        {
-            "name":"libidn",
-            "sources":[
-                {
-                    "type":"archive",
-                    "url":"https://ftp.gnu.org/gnu/libidn/libidn-1.34.tar.gz",
-                    "sha256":"3719e2975f2fb28605df3479c380af2cf4ab4e919e1506527e4c7670afff6e3c"
-                }
-            ],
-            "build-options":{
-                "arch":{
-                    "x86_64":{
-                        "prepend-pkg-config-path":"/app/lib32/pkgconfig:/usr/lib/i386-linux-gnu/pkgconfig",
-                        "ldflags":"-L/app/lib32",
-                        "append-path":"/usr/lib/sdk/toolchain-i386/bin",
-                        "env":{
-                            "CC":"i686-unknown-linux-gnu-gcc",
-                            "CXX":"i686-unknown-linux-gnu-g++"
-                        },
-                        "libdir":"/app/lib32"
-                    }
-                }
-            }
-        },
-        {
-            "name":"libgnome-keyring",
-            "config-opts":[
-                "--disable-static",
-                "--disable-gtk-doc",
-                "--disable-coverage",
-                "--disable-introspection"
-            ],
-            "sources":[
-                {
-                    "type":"archive",
-                    "url":"https://download.gnome.org/sources/libgnome-keyring/3.12/libgnome-keyring-3.12.0.tar.xz",
-                    "sha256":"c4c178fbb05f72acc484d22ddb0568f7532c409b0a13e06513ff54b91e947783"
-                },
-                {
-                    "type":"shell",
-                    "commands":[
-                        "autoreconf -fi"
-                    ]
-                }
-            ]
-        },
-        {
-            "name":"ubuntu-libcypto",
-            "buildsystem":"simple",
-            "sources":[
-                {
-                    "type":"file",
-                    "url":"http://mirrors.edge.kernel.org/ubuntu/pool/main/libx/libxcrypt/libcrypt1_4.4.27-1_amd64.deb",
-                    "sha256":"3fa566e9f861a08736cbc5a97562d9d6e4f0c00450fbeafcb6d7583423b04a98"
-                }
-            ],
-            "build-commands":[
-                  "ar x libcrypt1_4.4.27-1_amd64.deb",
-                  "tar -xvf data.tar.zst",
-                  "cp lib/x86_64-linux-gnu/* /app/lib/"
             ]
         },
         {

--- a/org.firestormviewer.FirestormViewer.json
+++ b/org.firestormviewer.FirestormViewer.json
@@ -1,7 +1,7 @@
 {
     "app-id":"org.firestormviewer.FirestormViewer",
     "runtime":"org.freedesktop.Platform",
-    "runtime-version":"23.08",
+    "runtime-version":"25.08",
     "sdk":"org.freedesktop.Sdk",
     "command":"firestorm-viewer",
     "separate-locales":false,


### PR DESCRIPTION
This PR does a few fixes.

The runtime is updated to 25.08 and in the process drops Vivox support.
CEF is "fixed", this seems to be tied to a few different problems, noticeably setting TMPDIR outside of .firestorm
Tidied up the startup script to remove options no longer relevant

Fixes #88 
Fixes #60
Fixes #84 